### PR TITLE
Change missing logical partitions from LOGERR to LOGINFO

### DIFF
--- a/partitionmanager.cpp
+++ b/partitionmanager.cpp
@@ -3328,7 +3328,7 @@ bool TWPartitionManager::Prepare_Super_Volume(TWPartition* twrpPart) {
 
     fstab.emplace_back(fstabEntry);
     if (!fs_mgr_update_logical_partition(&fstabEntry)) {
-        LOGERR("unable to update logical partition: %s\n", twrpPart->Get_Mount_Point().c_str());
+        LOGINFO("unable to update logical partition: %s\n", twrpPart->Get_Mount_Point().c_str());
         return false;
     }
 


### PR DESCRIPTION
Between Android versions, there may be different partitions
that make up super. Just because a partition that in fstab
is not in super doesn't necessarily mean there's a problem.

Change this message to information only so the end user
doesn't think there's a problem when there isn't one

Change-Id: I9cb99aabe20e20059e66cf0cf13cff5ed056f529

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [OmniRom Gerrit](https://gerrit.omnirom.org/#/admin/projects/android_bootable_recovery/)

For changes to device trees, use [TWRP Gerrit](https://gerrit.twrp.me/)

This guide explani how to use [Gerrit code review](https://forum.xda-developers.com/general/xda-university/guide-using-gerrit-code-review-t3720802)